### PR TITLE
Improve `//activity` capture in xa-lldb

### DIFF
--- a/xa-lldb
+++ b/xa-lldb
@@ -50,7 +50,7 @@ echo "Package: $PKG"
 echo "Manifest file: $MANIFEST"
 
 # Obtain main activity class name
-CLASS=`xmllint --xpath "string(//activity[1]/@*[local-name()='name'])" $MANIFEST`
+CLASS=`xpath $MANIFEST 'string(//activity[intent-filter/action/@android:name="android.intent.action.MAIN" and intent-filter/category/@android:name="android.intent.category.LAUNCHER"]/@android:name)' 2>/dev/null`
 if [ $? != 0 ]; then
 	exit 1
 fi


### PR DESCRIPTION
An `AndroidManifest.xml` file may contain multiple `<activity/>`
elements, and the first one is not necessarily the one that we want to
use.  (In all likelihood, it'll *never* be the one we want to use, if
the app contains more than one Activity, especially since there is no
ordering of `<activity/>` elements.)

This results in less than useful errors:

	$ xa-lldb app.csproj
	...
	Starting: Intent { act=android.intent.action.MAIN cat=[android.intent.category.LAUNCHER] cmp=com.example/md55whatever.EditTextActivity }
	java.lang.SecurityException: Permission Denial: starting Intent { act=android.intent.action.MAIN cat=[android.intent.category.LAUNCHER] flg=0x10000000 cmp=com.example/md5whatever.EditTextActivity } from null (pid=14173, uid=2000) not exported from uid 10125
		at android.os.Parcel.readException(Parcel.java:1472)
		at android.os.Parcel.readException(Parcel.java:1426)
		at android.app.ActivityManagerProxy.startActivityAsUser(ActivityManagerNative.java:2161)
		at com.android.commands.am.Am.runStart(Am.java:680)
		at com.android.commands.am.Am.onRun(Am.java:270)
		at com.android.internal.os.BaseCommand.run(BaseCommand.java:47)
		at com.android.commands.am.Am.main(Am.java:76)
		at com.android.internal.os.RuntimeInit.nativeFinishInit(Native Method)
		at com.android.internal.os.RuntimeInit.main(RuntimeInit.java:259)
		at dalvik.system.NativeStart.main(Native Method)

(Worse, the above error can only be worked around by manually editing
`xa-lldb` so that `CLASS=` refers to the correct name.)

Update the default `$CLASS` value so that instead of the *first*
`<activity/>` found within `AndroidManifest.xml`, we instead use the
first activity with the `MAIN` action and `LAUNCHER` category.  This
ensures that we try to launch a *sensible* activity.